### PR TITLE
feat: add standard pipeline for engine images

### DIFF
--- a/.github/workflows/engine_image_release.yml
+++ b/.github/workflows/engine_image_release.yml
@@ -1,0 +1,58 @@
+name: engine_image_release
+
+on:
+  workflow_call:
+    inputs:
+      defaultBranchName:
+        default: master
+        type: string
+      dockerImageTarget:
+        default: base_package
+        type: string
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: add build details
+        run: |
+          pip install hamlet
+          hamlet engine add-engine-source-build
+
+      - name: docker meta details
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{github.repository}}
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern={{version}}
+            type=edge,branch={{inputs.defaultBranchName}}
+            type=sha
+
+      - name: build and push container
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/{{inputs.defaultBranchName}}' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: ${{ inputs.dockerImageTarget }}


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- We use a standard process for publishing the images so this aligns with using a reusable workflow for the creation of the images

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Was updating the versions of the actions that we using the workflows and found that there is a lot of duplication across our repositories for this process

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

